### PR TITLE
商品削除機能の追加

### DIFF
--- a/app/assets/javascripts/items/popup.js
+++ b/app/assets/javascripts/items/popup.js
@@ -1,0 +1,12 @@
+$(function(){
+  $(".item-detail__contents__inner__details__confirm-delete-item").on("click", function(e) {
+    e.preventDefault();
+    console.log(this);
+    $("#item-delete-confimation-popup").addClass("active");
+  })
+  $(".content__lower").on("click", ".content__lower--cancel" , function(e) {
+    e.preventDefault();
+    console.log(this);
+    $("#item-delete-confimation-popup").removeClass("active");
+  })
+})

--- a/app/assets/javascripts/items/popup.js
+++ b/app/assets/javascripts/items/popup.js
@@ -1,12 +1,10 @@
 $(function(){
   $(".item-detail__contents__inner__details__confirm-delete-item").on("click", function(e) {
     e.preventDefault();
-    console.log(this);
     $("#item-delete-confimation-popup").addClass("active");
   })
   $(".content__lower").on("click", ".content__lower--cancel" , function(e) {
     e.preventDefault();
-    console.log(this);
     $("#item-delete-confimation-popup").removeClass("active");
   })
 })

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,3 +35,4 @@
 @import "users/new";
 @import "categories/categori";
 @import "categories/categori-show";
+@import "mypages/shipping-item-list"

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,4 +35,5 @@
 @import "users/new";
 @import "categories/categori";
 @import "categories/categori-show";
-@import "mypages/shipping-item-list"
+@import "mypages/shipping-item-list";
+@import "items/item-delete-popup"

--- a/app/assets/stylesheets/items/_item-delete-popup.scss
+++ b/app/assets/stylesheets/items/_item-delete-popup.scss
@@ -1,0 +1,62 @@
+#item-delete-confimation-popup{
+  display: none;
+}
+
+
+#item-delete-confimation-popup.active {
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(53, 53, 53, 0.842);
+  z-index: 1;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  .content {
+    height: 300px;
+    width: 600px;
+    background-color: white;
+    margin-top: 25px;
+    &__upper {
+      height: 75%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      .confirmation {
+        font-weight: 600;
+      }
+      .text {
+        font-size: 14px;
+      }
+    }
+    &__lower {
+      display: flex;
+      height: 25%;
+      border-top: solid 1px gray;
+      font-size: 14px;
+      & a {
+        text-decoration: none;
+      }
+      &--cancel {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 50%;
+        border-right: solid 1px gray;
+        height: 100%;
+        color: black;
+      }
+      &--delete {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 50%;
+        color: #0095FF;
+        height: 100%;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -143,6 +143,28 @@
           line-height: 60px;
           text-align: center;
         }
+        &__confirm-edit-item{
+          border: none;
+          margin-top: 16px;
+          height: 60px;
+          width: 620px;
+          background-color: #ea352d;
+          color: #FFFFFF;
+          font-size: 18px;
+          line-height: 60px;
+          text-align: center;
+        }
+        &__confirm-delete-item{
+          border: none;
+          margin-top: 16px;
+          height: 60px;
+          width: 620px;
+          background-color: #c0c0c0;
+          color: #FFFFFF;
+          font-size: 18px;
+          line-height: 60px;
+          text-align: center;
+        }
         &__text {
           padding-top: 32px;
           font-size: 18px;

--- a/app/assets/stylesheets/mypages/shipping-item-list.scss
+++ b/app/assets/stylesheets/mypages/shipping-item-list.scss
@@ -1,0 +1,150 @@
+.mypage__shipping-item-list{
+  width: 700px;
+  .header{
+    height:200px;
+    width: 100%;
+    background-image: image-url("mypage_background_image.jpg");
+    position: relative;
+    &__link{
+      display: block;
+      width: 100%;
+      position: absolute;
+      top: 50%;
+      transform: translate(0, -50%);
+      text-decoration: none;
+      color: #333333;
+      &__image{
+        height: 60px;
+        width: 60px;
+        border-radius: 60px;
+        display: block;
+        margin: 0 auto;
+      }
+      &__user-name{
+        margin: 8px 0 0;
+        text-align: center;
+        font-size: 14px;
+        font-weight: bold;
+      }
+      &__num{
+        margin: 8px 0 0 ;
+        display: flex;
+        font-size: 14px;
+        .assessment{
+        margin-left: auto;
+        }
+        .selling{
+          margin: 0 auto 0 16px;
+        }
+      }
+    }
+    
+  }
+  .notification, .transaction{
+    background-color: white;
+    &__header{
+      height: 72px;
+      line-height: 72px;
+      padding: 0 16px;
+      font-weight: bold;
+      margin-top: 40px;
+      background-color: white;
+    }
+    &__tabs{
+      width: 100%;
+      display: flex;
+      .tab{
+        width: 50%;
+        text-align: center;
+        font-size: 16px;
+        font-weight: bold;
+        line-height: 74px;
+        background-color: #eee;
+      }
+      .tab.active{
+        box-sizing: border-box;
+        width: 50%;
+        text-align: center;
+        font-size: 16px;
+        font-weight: bold;
+        line-height: 74px;
+        background-color: white;
+        border-top: 2px solid #ea352d;
+      }
+    }
+    &__contents{
+      .box__content{
+        display: none;
+      }
+      .box__content.show{
+        display: block;
+        .content{
+          box-sizing: border-box;
+          text-decoration: none;
+          display: block;
+          display: flex;
+          min-height: 80px;
+          padding: 16px;
+          border-bottom: 1px solid #eee;
+          color: #333;
+          font-size: 14px;
+          position: relative;
+          &__image{
+            height: 48px;
+            width:  48px;
+          }
+          &__main{
+            margin: 0 40px 0 20px;
+            &__text{
+              word-wrap: break-word;
+              width: 560px;
+            }
+            &__icon{
+              font-size: 16px;
+              color: #888;
+              float: left;
+              padding-top: 1.5px;
+            }
+            &__time{
+              color: #888;
+              float: left;
+            }
+            &__status-wait{
+              width: 60px;
+              height: 22px;
+              text-align: center;
+              line-height: 22px;
+              color: white;
+              background-color: #0099e8;
+              border-radius: 5px;
+            }
+            &__status-comp{
+              width: 60px;
+              height: 22px;
+              text-align: center;
+              line-height: 22px;
+              color: white;
+              background-color: gray;
+              border-radius: 5px;
+            }
+          }
+          &__icon{
+            height: 14px;
+            position: absolute;
+            top: calc(50% - 7px);
+            right: 20px;
+          }
+          &__index-btn{
+            text-align: center;
+            line-height: 48px;
+            width: 100%;
+            height: 48px;
+            background-color: #eee;
+            text-decoration: none;
+            color: #333;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -72,8 +72,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-      @item.destroy
-      redirect_to listings_mypage_path(current_user.id)
+      if @item.destroy
+        redirect_to listings_mypage_path(current_user.id)
+      else
+        redirect_to item_path(@item.id)
+      end
   end
 
   def purchase

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -75,7 +75,7 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     if @item.selling?
       @item.destroy if @item.user_id == current_user.id
-      redirect_to listings_mypage_path
+      redirect_to listings_mypage_path(current_user.id)
     else
       redirect_to item_path(params[:id])
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,11 @@
 class ItemsController < ApplicationController
   require 'payjp'
   before_action :authenticate_user!, except:[:index, :show]
-  before_action :set_item, only: [:show, :edit, :update, :purchase, :buy]
+  before_action :set_item, only: [:show, :edit, :update, :purchase, :buy, :destroy]
   before_action :set_card, only: [:purchase, :buy]
-  before_action :status_selling?, only: [:buy, :purchase, :edit, :update]
+  before_action :status_selling?, only: [:buy, :purchase, :edit, :update, :destroy]
   before_action :buyer?, only: [:buy, :purchase]
-  before_action :seller?, only: [:edit, :update]
+  before_action :seller?, only: [:edit, :update, :destroy]
 
   def index
     if Rails.env == "test" then
@@ -72,13 +72,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
-    if @item.selling?
-      @item.destroy if @item.user_id == current_user.id
+      @item.destroy
       redirect_to listings_mypage_path(current_user.id)
-    else
-      redirect_to item_path(params[:id])
-    end
   end
 
   def purchase

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -72,6 +72,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    @item = Item.find(params[:id])
+    if @item.selling?
+      @item.destroy if @item.user_id == current_user.id
+      redirect_to listings_mypage_path
+    else
+      redirect_to item_path(params[:id])
+    end
   end
 
   def purchase

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -30,6 +30,10 @@ class MypagesController < ApplicationController
     
   end
 
+  def listings
+    @items = Item.where(user_id: current_user.id)
+  end
+
   private
 
   def really_current_user?

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -31,7 +31,7 @@ class MypagesController < ApplicationController
   end
 
   def listings
-    @items = Item.where(user_id: current_user.id)
+    @items = current_user.items
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  has_many :images
+  has_many :images, dependent: :destroy
   belongs_to :user
   belongs_to :category
   belongs_to :size, optional: true

--- a/app/views/items/_item-delete-popup.html.haml
+++ b/app/views/items/_item-delete-popup.html.haml
@@ -11,10 +11,7 @@
           %br
           %br
           本当に削除しますか？
-          %br
-          -# 仮置き、商品詳細のサーバーサイド完成後に削除する
-          = "商品名: #{@item.name}"
-          
+
     .content__lower
       = link_to "" ,class: "content__lower--cancel" do
         キャンセル

--- a/app/views/items/_item-delete-popup.html.haml
+++ b/app/views/items/_item-delete-popup.html.haml
@@ -1,0 +1,22 @@
+#item-delete-confimation-popup
+  .content
+    .content__upper
+      .confirmation
+        確認
+      .text
+        %P
+          削除すると二度と復活できません。
+          %br
+          削除する代わりに停止することもできます。
+          %br
+          %br
+          本当に削除しますか？
+          %br
+          -# 仮置き、商品詳細のサーバーサイド完成後に削除する
+          = "商品名: #{@item.name}"
+          
+    .content__lower
+      = link_to "" ,class: "content__lower--cancel" do
+        キャンセル
+      = link_to item_path(@item.id), method: :delete, class: "content__lower--delete" do
+        削除する

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -74,7 +74,7 @@
               %span.items__edit__sell__form__require__option
                 任意
               %br
-              %input.brand_form{value: "#{@item.brand.name}"}
+              %input.brand_form{value: "#{@item.brand.name if @item.brand}"}
               = f.hidden_field :brand_id, type: "hidden"
               .brand__result__box
                 %ul.brand__result__lists

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -126,9 +126,10 @@
             =link_to edit_item_path(@item.id) do
               .item-detail__contents__inner__details__confirm-edit-item
                 商品の編集  
-            =link_to item_path(@item.id), method: :delete do
+            =link_to "" do
               .item-detail__contents__inner__details__confirm-delete-item
                 この商品を削除する
+      = render partial: 'item-delete-popup', locals: {item: @item}
 
       .item-detail__contents__inner__details__text
       %p.item-detail-explanation

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -121,6 +121,14 @@
         = link_to purchase_item_path(@item.id) do
           .item-detail__contents__inner__details__confirm-purchase-item
             購入画面に進む
+        - if user_signed_in?
+          - if @item.user_id == current_user.id
+            =link_to edit_item_path(@item.id) do
+              .item-detail__contents__inner__details__confirm-edit-item
+                商品の編集  
+            =link_to item_path(@item.id), method: :delete do
+              .item-detail__contents__inner__details__confirm-delete-item
+                この商品を削除する
 
       .item-detail__contents__inner__details__text
       %p.item-detail-explanation

--- a/app/views/mypages/_shipping-item-list.html.haml
+++ b/app/views/mypages/_shipping-item-list.html.haml
@@ -1,0 +1,40 @@
+.mypage__shipping-item-list
+  .transaction
+    .transaction__header
+      出品した商品
+    .transaction__tabs
+      .tab.active
+        出品中
+      .tab
+        取引中
+      .tab
+        売却済み
+    .transaction__contents
+      .box__content.show
+        - @items.each do |item|
+          = link_to item_path(item.id), class: "content" do
+            = image_tag "mypage_index.logo.png", class: "content__image"
+            .content__main
+              .content__main__text
+                = item.name
+              .content__main__status-wait
+                出品中
+            %i.fa.fa-chevron-right.content__icon
+
+
+
+      .box__content
+        = link_to "#", class: "content" do
+          = image_tag "mypage_index.logo.png", class: "content__image"
+          .content__main
+            .content__main__text
+              取引中の商品はありません
+          %i.fa.fa-chevron-right.content__icon
+
+      .box__content
+        = link_to "#", class: "content" do
+          = image_tag "mypage_index.logo.png", class: "content__image"
+          .content__main
+            .content__main__text
+              売却済みの商品はありません
+          %i.fa.fa-chevron-right.content__icon

--- a/app/views/mypages/_side-bar.html.haml
+++ b/app/views/mypages/_side-bar.html.haml
@@ -27,7 +27,7 @@
             出品する
             %i.fa.fa-angle-right.fa-2x.fa-pull-right
       %li
-        = link_to "" do
+        = link_to listings_mypage_path do
           .myside-bar-nav-list-item
             出品した商品 - 出品中
             %i.fa.fa-angle-right.fa-2x.fa-pull-right

--- a/app/views/mypages/listings.html.haml
+++ b/app/views/mypages/listings.html.haml
@@ -1,0 +1,8 @@
+= render "items/top-page-header"
+- breadcrumb :mypages
+= render "layouts/breadcrumbs"
+%main.big-container
+  %main.my-container
+    = render "side-bar"
+    = render "shipping-item-list"
+= render "items/top-page-footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     member do
       get "edit_identification", to: "mypages#identification"
       get "logout", to: "mypages#logout"
+      get "listings", to: "mypages#listings"
     end
   end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -372,6 +372,55 @@ describe ItemsController do
     end
   end
 
+
+  let(:user) { create(:user) }
+
+  describe 'DELETE destroy' do
+
+    context 'can delete' do
+      it 'item status is selling' do
+        login user
+        item = create(:item1, user_id: user.id, status: "selling")
+        expect do
+          delete :destroy, params: { id: item.id }, session: {}
+        end.to change(Item, :count).by(-1)
+      end
+
+      it "redirect to listings_mypage_path" do
+        login user
+        item = create(:item1, user_id: user.id, status: "selling")
+        delete :destroy, params: { id: item.id }, session: {}
+        expect(response).to redirect_to listings_mypage_path(user.id)
+      end
+    end
+
+    context 'can not delete' do
+      it 'item status is not selling' do
+        login user
+        item = create(:item1, user_id: user.id, status: "contract")
+        expect do
+          delete :destroy, params: { id: item.id }, session: {}
+        end.to change(Item, :count).by(0)
+      end
+
+      it 'item.user_id is not current_user.id' do
+        login user
+        another_user = create(:user)
+        item = create(:item1, user_id: another_user.id, status: "selling")
+        expect do
+          delete :destroy, params: { id: item.id }, session: {}
+        end.to change(Item, :count).by(0)
+      end
+
+      it "redirect to item_path" do
+        login user
+        item = create(:item1, user_id: user.id, status: "contract")
+        delete :destroy, params: { id: item.id }
+        expect(response).to redirect_to item_path(item.id)
+      end
+    end
+  end
+
   # describe "#buy" do
   #   context "SOLDしていない" do
   #     before do

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -82,5 +82,24 @@ FactoryBot.define do
     end
     
   end
+
+  factory :item1, class: Item do
+    name                  {Faker::Lorem.characters(number: 1..40)}
+    damage                {Faker::Number.within(range: 0..5)}
+    postage_side          {Faker::Number.within(range: 0..1)}
+    delivery_method       {Faker::Number.within(range: 0..8)}
+    prefecture_id         {Faker::Number.within(range: 1..47)}
+    arrival               {Faker::Number.within(range: 0..2)}
+    status                {Faker::Number.within(range: 0..3)}
+    price                 {Faker::Number.within(range: 300..9999999)}
+    text                  {Faker::Lorem.characters(number: 1..1000)}
+    created_at            {Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
+    size
+    user
+    category
+    after(:build) do |item|
+      item.images << FactoryBot.build(:image)
+    end
+  end
   
 end


### PR DESCRIPTION
# why
ユーザーが商品の出品を取り消すことができるようにするため。＝登録商品の削除。

# what
登録した商品の削除
商品の状況（購入済み等）により、削除不可のバリデーションを設定する。

controller testの実施
以下、確認項目
・商品の削除ができる。
・出品者とログイン中のユーザーが異なる場合は削除できない。
・商品の状態が出品中でない場合は削除できない。

[![Image from Gyazo](https://i.gyazo.com/0ab384fedc5ecb055d41a066f6342b24.gif)](https://gyazo.com/0ab384fedc5ecb055d41a066f6342b24)