### PR TITLE
new-product-details

### DIFF
--- a/app/assets/javascripts/items/show.js
+++ b/app/assets/javascripts/items/show.js
@@ -1,8 +1,8 @@
-
-
-// var thumbs =document.querySelectorAll('.picture');
-// for (var i =0 ; i < picture.length; i++ ) {
-//   thumbs[i].onclick = function() {
-//   document.getElementById('picture__m').src = this.dataset.imagesrc;
-//   };
-// }
+$(function() {
+  $('.picture__m').eq(0).css("display", "block");
+  $('.picture').hover(function() {
+    $('.picture__m').css("display", "none");
+    var index = $('.picture').index(this);
+    $('.picture__m').eq(index).css("display", "block");
+  });
+});

--- a/app/assets/javascripts/items/show.js
+++ b/app/assets/javascripts/items/show.js
@@ -1,0 +1,8 @@
+
+
+// var thumbs =document.querySelectorAll('.picture');
+// for (var i =0 ; i < picture.length; i++ ) {
+//   thumbs[i].onclick = function() {
+//   document.getElementById('picture__m').src = this.dataset.imagesrc;
+//   };
+// }

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -23,12 +23,11 @@
         float: left;
         width: 300px;
         height: 420px;
-        overflow: hidden;
         &__main__thumbnail {
           position: relative;
-          display: none;
           opacity: 1;
           .picture__m{
+            display: none;
           }
         .item__badge {
           border-color: red transparent transparent transparent;

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -26,7 +26,7 @@
         overflow: hidden;
         &__main__thumbnail {
           position: relative;
-          display: flex;
+          display: none;
           opacity: 1;
           .picture__m{
           }
@@ -55,15 +55,6 @@
           display: inline-flex;
           flex-wrap: wrap;
           justify-content: flex-start;
-          &__.slick-next{
-            right: 20px; z-index: 100;
-          }
-          &__.slick-prev{
-            left: 15px; z-index: 100;
-          }
-          &__.slick-current{
-            opacity: 0.5;
-          }
         }
       }
       &__details, table {

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -23,36 +23,46 @@
         float: left;
         width: 300px;
         height: 420px;
-        &__main {
+        overflow: hidden;
+        &__main__thumbnail {
           position: relative;
-          height: 300px;
-          .item__badge {
-            border-color: red transparent transparent transparent;
-            border-width: 120px 120px 0 0;
+          display: flex;
+          opacity: 1;
+          .picture__m{
+          }
+        .item__badge {
+          border-color: red transparent transparent transparent;
+          border-width: 120px 120px 0 0;
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 0;
+          height: 0;
+          border-style: solid;
+          &__text {
+            top: 15px;
+            left: -5px;
+            font-size: 35px;
+            transform: rotate(-45deg);
+            color: white;
             position: absolute;
-            top: 0;
-            left: 0;
-            width: 0;
-            height: 0;
-            border-style: solid;
-            &__text {
-              top: 15px;
-              left: -5px;
-              font-size: 35px;
-              transform: rotate(-45deg);
-              color: white;
-              position: absolute;
             }
           }
         }
-        &__sub {
+        &__sub__thumbnail-thumb {
           float: left;
           height: 60px;
           display: inline-flex;
           flex-wrap: wrap;
           justify-content: flex-start;
-          .picture{
-            height: 60px;
+          &__.slick-next{
+            right: 20px; z-index: 100;
+          }
+          &__.slick-prev{
+            left: 15px; z-index: 100;
+          }
+          &__.slick-current{
+            opacity: 0.5;
           }
         }
       }

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -210,7 +210,6 @@
           &__effort-for-safety {
             float: right;
             margin: 8px 0px 0px 44px;
-            
           }
           &__effort-for-safety * , & .link_to {
             @include mouseover__thincolor();

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,7 +11,7 @@
         .item-detail__contents__inner__pictures__main__thumbnail
           - @item.images.each do |images|
             %li.picture__m
-              = image_tag "#{@item.images.first.name}", size: '300x300'
+              = image_tag "#{images.name}", size: '300x300'
               - if @item.status != 'selling'
                 .item__badge
                 .item__badge__text

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,17 +6,20 @@
 
       .item-detail__contents__inner__name
         = @item.name
+
       .item-detail__contents__inner__pictures
-        %ur.item-detail__contents__inner__pictures__main__thumbnail
-          - if @item.status != 'selling'
-            .item__badge
-            .item__badge__text
-              SOLD
-          = image_tag "#{@item.images.first.name}", size: '300x300', data_imagesrc: "#{@item.images.first.name}"
+        .item-detail__contents__inner__pictures__main__thumbnail
+          - @item.images.each do |images|
+            %li.picture__m
+              = image_tag "#{@item.images.first.name}", size: '300x300'
+              - if @item.status != 'selling'
+                .item__badge
+                .item__badge__text
+                  SOLD
         %ul.item-detail__contents__inner__pictures__sub__thumbnail-thumb
           - @item.images.each do |image|
             %li.picture
-              = image_tag "#{image.name}", size: '60x60', class:'.picture', data_imagesrc: "#{image.name}"
+              = image_tag "#{image.name}", size: '60x60'
       %table.item-detail__contents__inner__details
         %tr
           %th
@@ -44,14 +47,14 @@
               カテゴリー
           %td
             .item-detail__contents__inner__details__category-main
-              = link_to @item.category.root.name, "#", class: 'link_to'
+              = link_to @item.category.root.name, category_path(@item.category.root.id), class: 'link_to'
             / おそらくeach文でカテゴリを取り出すため、クラス名をmainとsubに分けた
             .item-detail__contents__inner__details__category-sub
               = fa_icon 'angle-right', class: 'item-detail__contents__inner__details__category-sub__angle-right'
-              = link_to @item.category.parent.name, "#", class: 'link_to'
+              = link_to @item.category.parent.name, category_path(@item.category.parent.id), class: 'link_to'
             .item-detail__contents__inner__details__category-sub
               = fa_icon 'angle-right', class: 'item-detail__contents__inner__details__category-sub__angle-right'
-              = link_to @item.category.name, "#", class: 'link_to'
+              = link_to @item.category.name, category_path(@item.category.id), class: 'link_to'
         %tr
           %th
             %p

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,18 +6,17 @@
 
       .item-detail__contents__inner__name
         = @item.name
-
       .item-detail__contents__inner__pictures
-        .item-detail__contents__inner__pictures__main
+        %ur.item-detail__contents__inner__pictures__main__thumbnail
           - if @item.status != 'selling'
             .item__badge
             .item__badge__text
               SOLD
-          = image_tag "#{@item.images.first.name}", size: '300x300'
-        %ul.item-detail__contents__inner__pictures__sub
+          = image_tag "#{@item.images.first.name}", size: '300x300', data_imagesrc: "#{@item.images.first.name}"
+        %ul.item-detail__contents__inner__pictures__sub__thumbnail-thumb
           - @item.images.each do |image|
             %li.picture
-              = image_tag "#{image.name}", size: '60x60'
+              = image_tag "#{image.name}", size: '60x60', class:'.picture', data_imagesrc: "#{image.name}"
       %table.item-detail__contents__inner__details
         %tr
           %th

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -208,6 +208,10 @@
                 .item__badge__text
                   SOLD
               = image_tag "#{another_item.images.first.name}", size: '220x220'
+              - if another_item.status != 'selling'
+                .item__badge
+                .item__badge__text
+                  SOLD
             .item-detail__another-items__items__item-box__item-link__simple-detail
               .item-detail__another-items__items__item-box__item-link__simple-detail__name
                 %p

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,5 +9,6 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+
   %body
     = yield


### PR DESCRIPTION
why
商品詳細画面の商品画像のスライドや、ブランドのその他商品、商品説明欄の空行をできるようにする。

what
SUBの写真を選択した時にメインの写真の場所にSUBの写真が表示される。